### PR TITLE
added check to prevent Index Out of Bounds Exception

### DIFF
--- a/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/components/DrawOnClickLabel.kt
+++ b/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/components/DrawOnClickLabel.kt
@@ -28,7 +28,7 @@ internal fun DrawOnClickLabel(
     onWidthChange: (Float) -> Unit
 ) {
 
-    if (offsetsIndexed.isNotEmpty()) {
+    if (offsetsIndexed.isNotEmpty() && data.size > onClickIndex) {
 
         val currentData = data[onClickIndex]
         val isRightPosition = onClickIndex > data.size.div(2)


### PR DESCRIPTION
ref: [AND-735](https://quipper.atlassian.net/browse/AND-735)

### Approach:
- added a check `data.size > onClickIndex` in `DrawOnClickLabel`

### Notes:
- crash signature is not identical but very similar, it should fix the same issue from crashlytics as well

## How to Test:
- apply patch
```
diff --git a/app/src/main/java/com/quipper/chart/MainActivity.kt b/app/src/main/java/com/quipper/chart/MainActivity.kt
index cbad22f..850418b 100644
--- a/app/src/main/java/com/quipper/chart/MainActivity.kt
+++ b/app/src/main/java/com/quipper/chart/MainActivity.kt
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun createDummyChartData(): ChartData {
+    fun createDummyChartData(): ChartData {
         return ChartData(
             listOf(
                 ChartValue(10, "2022-10-20"),
diff --git a/build.gradle b/build.gradle
index 88b3828..eaf7c0c 100644
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.0-beta04' apply false
-    id 'com.android.library' version '7.2.0-beta04' apply false
+    id 'com.android.application' version '7.2.2' apply false
+    id 'com.android.library' version '7.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
 }
 
diff --git a/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt b/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt
index b0d7831..753d2dc 100644
--- a/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt
+++ b/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt
@@ -10,6 +10,8 @@ import com.quipper.qandroidcomposechart.components.*
 import com.quipper.qandroidcomposechart.models.ChartClickValue
 import com.quipper.qandroidcomposechart.models.ChartData
 import com.quipper.qandroidcomposechart.models.ChartTheme
+import com.quipper.qandroidcomposechart.models.ChartValue
+import kotlinx.coroutines.delay
 
 @Composable
 fun QChart(
@@ -23,6 +25,22 @@ fun QChart(
     chartData: ChartData,
     onValueClicked: (chartClickValue: ChartClickValue) -> Unit
 ) {
+    val testChartData = produceState(
+        initialValue = ChartData(listOf(
+            ChartValue(10, "2022-10-20"),
+            ChartValue(13, "2022-10-20"),
+            ChartValue(25, "2022-10-20"),
+            ChartValue(50, "2022-10-20"),
+            ChartValue(60, "2022-10-20"),
+            ChartValue(30, "2022-10-20"),
+            ChartValue(10, "2022-10-20"),
+        ))
+    ) {
+        delay(3000)
+        value = ChartData(listOf(
+            ChartValue(10, "2022-10-20"),
+            ChartValue(60, "2022-10-20"),))
+    }.value
 
     Box(
         modifier = modifier
@@ -51,7 +69,7 @@ fun QChart(
             mutableStateOf(0f)
         }
 
-        LaunchedEffect(key1 = chartData) {
+        LaunchedEffect(key1 = testChartData) {
             isFirstClickDefine = true
             isFirstOnClick = false
             offsetsIndexed = emptyList()
@@ -67,7 +85,7 @@ fun QChart(
             chartTheme = chartTheme,
             offsetsIndexed = offsetsIndexed,
             onClickIndex = onClickIndex,
-            chartData = chartData,
+            chartData = testChartData,
             isFirstClickDefine = isFirstClickDefine,
             valueTextStyle = chartTheme.valueTextStyle,
             onSetClickIndex = { onClickIndex = it },
@@ -77,7 +95,7 @@ fun QChart(
         DrawOnClickLabel(
             offsetsIndexed = offsetsIndexed,
             onClickIndex = onClickIndex,
-            data = chartData.data,
+            data = testChartData.data,
             onWidthChange = { labelWidth = it },
             chartTheme = chartTheme
         )
@@ -85,14 +103,14 @@ fun QChart(
             title = chartModalTitle,
             offsetsIndexed = offsetsIndexed,
             isFirstOnClick = isFirstOnClick,
-            chartData = chartData,
+            chartData = testChartData,
             onClickIndex = onClickIndex,
             labelWidth = labelWidth,
             chartTheme = chartTheme
         )
         DrawXValueLegend(
             height = chartHeight,
-            data = chartData.data,
+            data = testChartData.data,
             chartTheme = chartTheme,
             onClickIndex = onClickIndex,
             onValueClicked = { index, value ->

```
- open application
- you should see chart
- the value that is highlighted should be the last item (6th item)
- after 3 seconds the items should change
- it shouldn't crash


### Removing the fix Patch (to check the crash)
- apply patch
```
diff --git a/app/src/main/java/com/quipper/chart/MainActivity.kt b/app/src/main/java/com/quipper/chart/MainActivity.kt
index cbad22f..850418b 100644
--- a/app/src/main/java/com/quipper/chart/MainActivity.kt
+++ b/app/src/main/java/com/quipper/chart/MainActivity.kt
@@ -27,7 +27,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun createDummyChartData(): ChartData {
+    fun createDummyChartData(): ChartData {
         return ChartData(
             listOf(
                 ChartValue(10, "2022-10-20"),
diff --git a/build.gradle b/build.gradle
index 88b3828..eaf7c0c 100644
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.2.0-beta04' apply false
-    id 'com.android.library' version '7.2.0-beta04' apply false
+    id 'com.android.application' version '7.2.2' apply false
+    id 'com.android.library' version '7.2.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
 }
 
diff --git a/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt b/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt
index b0d7831..753d2dc 100644
--- a/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt
+++ b/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/QChart.kt
@@ -10,6 +10,8 @@ import com.quipper.qandroidcomposechart.components.*
 import com.quipper.qandroidcomposechart.models.ChartClickValue
 import com.quipper.qandroidcomposechart.models.ChartData
 import com.quipper.qandroidcomposechart.models.ChartTheme
+import com.quipper.qandroidcomposechart.models.ChartValue
+import kotlinx.coroutines.delay
 
 @Composable
 fun QChart(
@@ -23,6 +25,22 @@ fun QChart(
     chartData: ChartData,
     onValueClicked: (chartClickValue: ChartClickValue) -> Unit
 ) {
+    val testChartData = produceState(
+        initialValue = ChartData(listOf(
+            ChartValue(10, "2022-10-20"),
+            ChartValue(13, "2022-10-20"),
+            ChartValue(25, "2022-10-20"),
+            ChartValue(50, "2022-10-20"),
+            ChartValue(60, "2022-10-20"),
+            ChartValue(30, "2022-10-20"),
+            ChartValue(10, "2022-10-20"),
+        ))
+    ) {
+        delay(3000)
+        value = ChartData(listOf(
+            ChartValue(10, "2022-10-20"),
+            ChartValue(60, "2022-10-20"),))
+    }.value
 
     Box(
         modifier = modifier
@@ -51,7 +69,7 @@ fun QChart(
             mutableStateOf(0f)
         }
 
-        LaunchedEffect(key1 = chartData) {
+        LaunchedEffect(key1 = testChartData) {
             isFirstClickDefine = true
             isFirstOnClick = false
             offsetsIndexed = emptyList()
@@ -67,7 +85,7 @@ fun QChart(
             chartTheme = chartTheme,
             offsetsIndexed = offsetsIndexed,
             onClickIndex = onClickIndex,
-            chartData = chartData,
+            chartData = testChartData,
             isFirstClickDefine = isFirstClickDefine,
             valueTextStyle = chartTheme.valueTextStyle,
             onSetClickIndex = { onClickIndex = it },
@@ -77,7 +95,7 @@ fun QChart(
         DrawOnClickLabel(
             offsetsIndexed = offsetsIndexed,
             onClickIndex = onClickIndex,
-            data = chartData.data,
+            data = testChartData.data,
             onWidthChange = { labelWidth = it },
             chartTheme = chartTheme
         )
@@ -85,14 +103,14 @@ fun QChart(
             title = chartModalTitle,
             offsetsIndexed = offsetsIndexed,
             isFirstOnClick = isFirstOnClick,
-            chartData = chartData,
+            chartData = testChartData,
             onClickIndex = onClickIndex,
             labelWidth = labelWidth,
             chartTheme = chartTheme
         )
         DrawXValueLegend(
             height = chartHeight,
-            data = chartData.data,
+            data = testChartData.data,
             chartTheme = chartTheme,
             onClickIndex = onClickIndex,
             onValueClicked = { index, value ->
diff --git a/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/components/DrawOnClickLabel.kt b/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/components/DrawOnClickLabel.kt
index 08d3b19..19ab1db 100644
--- a/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/components/DrawOnClickLabel.kt
+++ b/qandroidcomposechart/src/main/java/com/quipper/qandroidcomposechart/components/DrawOnClickLabel.kt
@@ -28,7 +28,7 @@ internal fun DrawOnClickLabel(
     onWidthChange: (Float) -> Unit
 ) {
 
-    if (offsetsIndexed.isNotEmpty() && data.size > onClickIndex) {
+    if (offsetsIndexed.isNotEmpty()) {
 
         val currentData = data[onClickIndex]
         val isRightPosition = onClickIndex > data.size.div(2)

```